### PR TITLE
Respect verbose flag in seed_everything

### DIFF
--- a/src/lightning/fabric/CHANGELOG.md
+++ b/src/lightning/fabric/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed with adding a missing device id for pytorch 2.8 ([#21105](https://github.com/Lightning-AI/pytorch-lightning/pull/21105))
+- Respect `verbose=False` in `seed_everything` when no seed is provided
 
 
 ---

--- a/src/lightning/fabric/utilities/seed.py
+++ b/src/lightning/fabric/utilities/seed.py
@@ -40,7 +40,8 @@ def seed_everything(seed: Optional[int] = None, workers: bool = False, verbose: 
         env_seed = os.environ.get("PL_GLOBAL_SEED")
         if env_seed is None:
             seed = 0
-            rank_zero_warn(f"No seed found, seed set to {seed}")
+            if verbose:
+                rank_zero_warn(f"No seed found, seed set to {seed}")
         else:
             try:
                 seed = int(env_seed)

--- a/tests/tests_fabric/utilities/test_seed.py
+++ b/tests/tests_fabric/utilities/test_seed.py
@@ -72,6 +72,14 @@ def test_seed_everything_accepts_valid_seed_from_env():
     assert seed_everything() == 17
 
 
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_seed_everything_non_verbose_no_warning():
+    """Ensure that no warning is emitted when verbose is False and no seed is provided."""
+    with warnings.catch_warnings(record=True) as caught:
+        seed_everything(verbose=False)
+    assert caught == []
+
+
 def test_reset_seed_no_op():
     """Test that the reset_seed function is a no-op when seed_everything() was not used."""
     assert "PL_GLOBAL_SEED" not in os.environ


### PR DESCRIPTION
## Summary
- avoid emitting a warning when `seed_everything` is called with `verbose=False`
- add regression test covering silent seeding
- document the fix in Fabric changelog

## Testing
- `pre-commit run --files src/lightning/fabric/utilities/seed.py tests/tests_fabric/utilities/test_seed.py src/lightning/fabric/CHANGELOG.md`
- `PYTHONPATH=src pytest tests/tests_fabric/utilities/test_seed.py`


------
https://chatgpt.com/codex/tasks/task_e_68b931df0e648333b4edde23bf618544

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--4.org.readthedocs.build/en/4/

<!-- readthedocs-preview pytorch-lightning end -->