### PR TITLE
Optimize SimpleProfiler duration aggregation (use math.fsum)

### DIFF
--- a/src/lightning/pytorch/profilers/simple.py
+++ b/src/lightning/pytorch/profilers/simple.py
@@ -14,13 +14,13 @@
 """Profiler to check if there are any bottlenecks in your code."""
 
 import logging
+import math
 import os
 import time
 from collections import defaultdict
 from pathlib import Path
 from typing import Optional, Union
 
-import torch
 from typing_extensions import override
 
 from lightning.pytorch.profilers.profiler import Profiler
@@ -86,9 +86,8 @@ class SimpleProfiler(Profiler):
         report = []
 
         for a, d in self.recorded_durations.items():
-            d_tensor = torch.tensor(d)
             len_d = len(d)
-            sum_d = torch.sum(d_tensor).item()
+            sum_d = math.fsum(d)
             percentage_d = 100.0 * sum_d / total_duration
 
             report.append((a, sum_d / len_d, len_d, sum_d, percentage_d))
@@ -100,8 +99,7 @@ class SimpleProfiler(Profiler):
     def _make_report(self) -> _TABLE_DATA:
         report = []
         for action, d in self.recorded_durations.items():
-            d_tensor = torch.tensor(d)
-            sum_d = torch.sum(d_tensor).item()
+            sum_d = math.fsum(d)
 
             report.append((action, sum_d / len(d), sum_d))
 

--- a/tests/tests_pytorch/profilers/test_profiler.py
+++ b/tests/tests_pytorch/profilers/test_profiler.py
@@ -194,6 +194,23 @@ def test_simple_profiler_logs(tmp_path, caplog, simple_profiler):
     assert caplog.text.count("Profiler Report") == 2
 
 
+def test_simple_profiler_uses_math_fsum(monkeypatch):
+    profiler = SimpleProfiler()
+    profiler.recorded_durations["action"] = [1.0, 2.0, 3.0]
+    profiler.start_time = 0.0
+
+    fsum_calls: list[list[float]] = []
+
+    def _fake_fsum(values):
+        fsum_calls.append(list(values))
+        return sum(values)
+
+    monkeypatch.setattr("lightning.pytorch.profilers.simple.math.fsum", _fake_fsum)
+
+    profiler._make_report()
+    assert fsum_calls == [[1.0, 2.0, 3.0]]
+
+
 @pytest.mark.parametrize("extended", [True, False])
 @patch("time.perf_counter", return_value=70)
 def test_simple_profiler_summary(tmp_path, extended):


### PR DESCRIPTION
### Motivation
- Avoid unnecessary creation of PyTorch tensors when aggregating recorded durations in `SimpleProfiler`, which incurs CPU overhead and potential synchronization costs.

### Description
- Replace `torch.tensor(...); torch.sum(...).item()` with `math.fsum(...)` in `_make_report` and `_make_report_extended`, and remove the unused `torch` import.
- Add a regression test `test_simple_profiler_uses_math_fsum` that monkeypatches `math.fsum` to assert the profiler uses it for aggregation.

### Testing
- Added unit test `tests/tests_pytorch/profilers/test_profiler.py::test_simple_profiler_uses_math_fsum` to verify `math.fsum` is invoked; the test was added but could not be executed in this environment due to `ModuleNotFoundError: No module named 'lightning'` when running `pytest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f00a792c8333b1de18cb7cff9719)