### PR TITLE
Filter optional CLI callbacks from Trainer initialization

### DIFF
--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -625,7 +625,11 @@ class LightningCLI:
             kwargs: Any custom trainer arguments.
 
         """
-        extra_callbacks = [self._get(self.config_init, c) for c in self._parser(self.subcommand).callback_keys]
+        extra_callbacks: list[Callback] = []
+        for key in self._parser(self.subcommand).callback_keys:
+            callback = self._get(self.config_init, key)
+            if callback is not None:
+                extra_callbacks.append(callback)
         trainer_config = {**self._get(self.config_init, "trainer", default={}), **kwargs}
         return self._instantiate_trainer(trainer_config, extra_callbacks)
 

--- a/tests/tests_pytorch/test_cli.py
+++ b/tests/tests_pytorch/test_cli.py
@@ -191,6 +191,17 @@ def test_lightning_cli_single_arg_callback():
     assert not isinstance(cli.config_init.trainer, list)
 
 
+def test_lightning_cli_optional_callback_subclass_mode():
+    class MyLightningCLI(LightningCLI):
+        def add_arguments_to_parser(self, parser):
+            parser.add_lightning_class_args(Callback, "optional_callback", subclass_mode=True, required=False)
+
+    with mock.patch("sys.argv", ["any.py"]):
+        cli = MyLightningCLI(BoringModel, run=False)
+
+    assert all(isinstance(callback, Callback) for callback in cli.trainer.callbacks)
+
+
 @pytest.mark.parametrize("run", [False, True])
 def test_lightning_cli_configurable_callbacks(cleandir, run):
     class MyLightningCLI(LightningCLI):


### PR DESCRIPTION
### Motivation
- When `LightningCLI` registers optional callback argument groups (e.g., via `add_lightning_class_args(..., subclass_mode=True, required=False)`), those groups can resolve to `None` and the previous code appended `None` into the trainer `callbacks` list, producing surprising/incorrect Trainer state.

### Description
- Change `instantiate_trainer` to filter out `None` entries when collecting `extra_callbacks` from `self._parser(...).callback_keys` so only actual callbacks are appended to the Trainer config; this avoids injecting `None` into `trainer.callbacks`.
- Add a regression test `test_lightning_cli_optional_callback_subclass_mode` verifying that declaring an optional subclass-mode callback group without passing any value does not inject `None` into `trainer.callbacks` and that all callbacks are real `Callback` instances.

### Testing
- Attempted to run the new test with `python -m pytest tests/tests_pytorch/test_cli.py -k "optional_callback_subclass_mode"`, but the test run failed early due to the test environment missing the `lightning` import (`ModuleNotFoundError: No module named 'lightning'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982d79a56a083338c5f192c90cbc20e)

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--7.org.readthedocs.build/en/7/

<!-- readthedocs-preview pytorch-lightning end -->